### PR TITLE
Use granular service plans.

### DIFF
--- a/credentials.example.yml
+++ b/credentials.example.yml
@@ -60,9 +60,8 @@ cf-client-secret-staging: CF_CLIENT_SECRET
 cf-token-url-staging: CF_TOKEN_URL
 cf-token-key-staging: CF_TOKEN_KEY
 
-broker-service-names-staging: "redis28-multinode"
+broker-service-names-staging: "redis28-multinode:free"
 broker-service-organization-staging: ""
-broker-service-plan-staging: ""
 
 cf-api-url-production: https://api.your.cf.installation
 cf-deploy-username-production: USERNAME
@@ -81,9 +80,8 @@ cf-client-secret-production: CF_CLIENT_SECRET
 cf-token-url-production: CF_TOKEN_URL
 cf-token-key-production: CF_TOKEN_KEY
 
-broker-service-names-production: "redis28-multinode"
+broker-service-names-production: "redis28-multinode:free"
 broker-service-organization-production: ""
-broker-service-plan-production: ""
 
 slack-channel: "#CHANNEL"
 slack-username: concourse

--- a/pipeline.yml
+++ b/pipeline.yml
@@ -186,9 +186,8 @@ jobs:
       BROKER_NAME: kubernetes-broker
       AUTH_USER: {{broker-auth-user-staging}}
       AUTH_PASS: {{broker-auth-pass-staging}}
-      SERVICE_NAMES: {{broker-service-names-staging}}
+      SERVICES: {{broker-service-names-staging}}
       SERVICE_ORGANIZATION: {{broker-service-organization-staging}}
-      SERVICE_PLAN: {{broker-service-plan-staging}}
 
 - name: acceptance-tests-staging
   plan:
@@ -330,9 +329,8 @@ jobs:
       BROKER_NAME: kubernetes-broker
       AUTH_USER: {{broker-auth-user-production}}
       AUTH_PASS: {{broker-auth-pass-production}}
-      SERVICE_NAMES: {{broker-service-names-production}}
+      SERVICES: {{broker-service-names-production}}
       SERVICE_ORGANIZATION: {{broker-service-organization-production}}
-      SERVICE_PLAN: {{broker-service-plan-production}}
 
 - name: acceptance-tests-production
   plan:


### PR DESCRIPTION
Uses "name:plan" values added in
https://github.com/18F/cg-pipeline-tasks/pull/22.

So we can enable some plans for a given service without enabling all of them.

@sharms 