### PR TITLE
Add single-node elasticsearch1.7 acceptance test.

### DIFF
--- a/acceptance/elasticsearch17/glide.lock
+++ b/acceptance/elasticsearch17/glide.lock
@@ -1,0 +1,20 @@
+hash: a09b480b8e0e9dc9ccd1ecf962614939053962c171ba3bfa98cbdc7f6d9d5d77
+updated: 2016-10-01T18:33:59.321249951-04:00
+imports:
+- name: github.com/cloudfoundry-community/go-cfenv
+  version: 96ad7376813bfd13c95af69ca5b4ef5725f6b335
+- name: github.com/mitchellh/mapstructure
+  version: ca63d7c062ee3c9f34db231e352b60012b4fd0c1
+- name: golang.org/x/net
+  version: cd95c68ba21fc7ee16ee38cc420473e3d8c4afd8
+  subpackages:
+  - context
+  - context/ctxhttp
+- name: gopkg.in/olivere/elastic.v2
+  version: eaecbad7a83e6b60f131825553e5eb7fd5a50b41
+- name: gopkg.in/olivere/elastic.v3
+  version: eaecbad7a83e6b60f131825553e5eb7fd5a50b41
+  subpackages:
+  - backoff
+  - uritemplates
+testImports: []

--- a/acceptance/elasticsearch17/glide.yaml
+++ b/acceptance/elasticsearch17/glide.yaml
@@ -1,0 +1,6 @@
+package: elasticsearch17-test
+import:
+- package: github.com/cloudfoundry-community/go-cfenv
+  version: ~1.14.0
+- package: gopkg.in/olivere/elastic.v2
+  version: ~3.0.55

--- a/acceptance/elasticsearch17/main.go
+++ b/acceptance/elasticsearch17/main.go
@@ -1,0 +1,70 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"os"
+	"os/signal"
+
+	"github.com/cloudfoundry-community/go-cfenv"
+	"gopkg.in/olivere/elastic.v2"
+)
+
+func checkStatus(err error) {
+	if err != nil {
+		log.Fatalf("error: %s", err.Error())
+	}
+}
+
+func waitForExit() {
+	c := make(chan os.Signal, 1)
+	signal.Notify(c, os.Interrupt, os.Kill)
+	<-c
+	os.Exit(0)
+}
+
+type Record struct {
+	Key   string
+	Value string
+}
+
+func main() {
+	// Get elasticsearch17-multinode credentials
+	env, _ := cfenv.Current()
+	services, _ := env.Services.WithLabel("elasticsearch17-multinode")
+	if len(services) != 1 {
+		log.Fatal("elasticsearch17-multinode service not found")
+	}
+	creds := services[0].Credentials
+
+	// Create elasticsearch client
+	url := fmt.Sprintf("%s:%s", creds["hostname"], creds["port"])
+	client, err := elastic.NewClient(elastic.SetURL(url))
+
+	// Set and check document
+	record := Record{Key: "key", Value: "value"}
+	_, err = client.Index().Index("test").Type("test").Id("1").BodyJson(record).Refresh(true).Do()
+	checkStatus(err)
+
+	query := elastic.NewTermQuery("key", "value")
+	results, err := client.Search().Index("test").Query(query).Do()
+	checkStatus(err)
+
+	if results.Hits.TotalHits != 1 {
+		log.Fatalf("should find exactly one record; found %d", results.Hits.TotalHits)
+	}
+
+	result := Record{}
+	err = json.Unmarshal(*results.Hits.Hits[0].Source, &result)
+	checkStatus(err)
+	if record.Value != "value" {
+		log.Fatalf("incorrect value: %s", result.Value)
+	}
+
+	_, err = client.DeleteIndex("test").Do()
+	checkStatus(err)
+
+	// Keep alive
+	waitForExit()
+}

--- a/acceptance/elasticsearch17/manifest.yml
+++ b/acceptance/elasticsearch17/manifest.yml
@@ -1,0 +1,9 @@
+applications:
+- name: elasticsearch17-test
+  buildpack: go_buildpack
+  command: elasticsearch17-test
+  health-check-type: none
+  no-route: true
+  env:
+    GOPACKAGENAME: elasticsearch17-test
+    GO15VENDOREXPERIMENT: 1

--- a/pipeline.yml
+++ b/pipeline.yml
@@ -227,26 +227,35 @@ jobs:
         PLAN_NAME: persistent
         SERVICE_INSTANCE_NAME: elasticsearch23-persistent
         TEST_PATH: kubernetes-config/acceptance/elasticsearch23
-    - task: acceptance-test-mysql56-persistent
+    - task: acceptance-test-elasticsearch17-persistent
       file: kubernetes-config/acceptance/run-acceptance-test.yml
       params:
         <<: *cf-staging
-        APP_NAME: mysql56-test
-        SERVICE_NAME: mysql56-multinode
+        APP_NAME: elasticsearch17-test
+        SERVICE_NAME: elasticsearch17-multinode
         PLAN_NAME: persistent
-        SERVICE_INSTANCE_NAME: mysql56-persistent
-        TEST_PATH: kubernetes-config/acceptance/sql
-        MANIFEST_FILE: manifest-mysql56-multinode.yml
-    - task: acceptance-test-postgresql94-persistent
-      file: kubernetes-config/acceptance/run-acceptance-test.yml
-      params:
-        <<: *cf-staging
-        APP_NAME: postgresql94-test
-        SERVICE_NAME: postgresql94-multinode
-        PLAN_NAME: persistent
-        SERVICE_INSTANCE_NAME: postgresql94-persistent
-        TEST_PATH: kubernetes-config/acceptance/sql
-        MANIFEST_FILE: manifest-postgresql94-multinode.yml
+        SERVICE_INSTANCE_NAME: elasticsearch17-persistent
+        TEST_PATH: kubernetes-config/acceptance/elasticsearch17
+    # - task: acceptance-test-mysql56-persistent
+    #   file: kubernetes-config/acceptance/run-acceptance-test.yml
+    #   params:
+    #     <<: *cf-staging
+    #     APP_NAME: mysql56-test
+    #     SERVICE_NAME: mysql56-multinode
+    #     PLAN_NAME: persistent
+    #     SERVICE_INSTANCE_NAME: mysql56-persistent
+    #     TEST_PATH: kubernetes-config/acceptance/sql
+    #     MANIFEST_FILE: manifest-mysql56-multinode.yml
+    # - task: acceptance-test-postgresql94-persistent
+    #   file: kubernetes-config/acceptance/run-acceptance-test.yml
+    #   params:
+    #     <<: *cf-staging
+    #     APP_NAME: postgresql94-test
+    #     SERVICE_NAME: postgresql94-multinode
+    #     PLAN_NAME: persistent
+    #     SERVICE_INSTANCE_NAME: postgresql94-persistent
+    #     TEST_PATH: kubernetes-config/acceptance/sql
+    #     MANIFEST_FILE: manifest-postgresql94-multinode.yml
 
 - name: deploy-kubernetes-production
   plan:
@@ -399,26 +408,35 @@ jobs:
         PLAN_NAME: persistent
         SERVICE_INSTANCE_NAME: elasticsearch23-persistent
         TEST_PATH: kubernetes-config/acceptance/elasticsearch23
-    - task: acceptance-test-mysql56-persistent
+    - task: acceptance-test-elasticsearch17-persistent
       file: kubernetes-config/acceptance/run-acceptance-test.yml
       params:
         <<: *cf-production
-        APP_NAME: mysql56-test
-        SERVICE_NAME: mysql56-multinode
+        APP_NAME: elasticsearch17-test
+        SERVICE_NAME: elasticsearch17-multinode
         PLAN_NAME: persistent
-        SERVICE_INSTANCE_NAME: mysql56-persistent
-        TEST_PATH: kubernetes-config/acceptance/sql
-        MANIFEST_FILE: manifest-mysql56-multinode.yml
-    - task: acceptance-test-postgresql94-persistent
-      file: kubernetes-config/acceptance/run-acceptance-test.yml
-      params:
-        <<: *cf-production
-        APP_NAME: postgresql94-test
-        SERVICE_NAME: postgresql94-multinode
-        PLAN_NAME: persistent
-        SERVICE_INSTANCE_NAME: postgresql94-persistent
-        TEST_PATH: kubernetes-config/acceptance/sql
-        MANIFEST_FILE: manifest-postgresql94-multinode.yml
+        SERVICE_INSTANCE_NAME: elasticsearch17-persistent
+        TEST_PATH: kubernetes-config/acceptance/elasticsearch17
+    # - task: acceptance-test-mysql56-persistent
+    #   file: kubernetes-config/acceptance/run-acceptance-test.yml
+    #   params:
+    #     <<: *cf-production
+    #     APP_NAME: mysql56-test
+    #     SERVICE_NAME: mysql56-multinode
+    #     PLAN_NAME: persistent
+    #     SERVICE_INSTANCE_NAME: mysql56-persistent
+    #     TEST_PATH: kubernetes-config/acceptance/sql
+    #     MANIFEST_FILE: manifest-mysql56-multinode.yml
+    # - task: acceptance-test-postgresql94-persistent
+    #   file: kubernetes-config/acceptance/run-acceptance-test.yml
+    #   params:
+    #     <<: *cf-production
+    #     APP_NAME: postgresql94-test
+    #     SERVICE_NAME: postgresql94-multinode
+    #     PLAN_NAME: persistent
+    #     SERVICE_INSTANCE_NAME: postgresql94-persistent
+    #     TEST_PATH: kubernetes-config/acceptance/sql
+    #     MANIFEST_FILE: manifest-postgresql94-multinode.yml
 
 resources:
 - name: pipeline-tasks


### PR DESCRIPTION
The new acceptance tests are copied and pasted from the existing elastic 2.3 tests, then downgraded to the previous version of the elastic client library. Since we'll be deprecating elastic 1.7 in a few months, I didn't think it was worth spending the extra five minutes on DRY tests.

@cnelson 