### PR TITLE
Randomize service instance names to avoid collisions.

### DIFF
--- a/acceptance/run-acceptance-test.sh
+++ b/acceptance/run-acceptance-test.sh
@@ -3,11 +3,6 @@
 set -e
 set -u
 
-function cleanup() {
-  cf delete -f ${APP_NAME}
-  cf delete-service -f ${SERVICE_INSTANCE_NAME}
-}
-
 function check_service() {
   counter=36
   until [ $counter -le 0 ]; do
@@ -20,7 +15,10 @@ function check_service() {
     let counter-=1
     sleep 5
   done
+  return 1
 }
+
+SERVICE_INSTANCE_NAME=$(mktemp "${SERVICE_NAME}-${PLAN_NAME}-XXXXXX")
 
 cd ${TEST_PATH}
 
@@ -29,8 +27,6 @@ cf auth $CF_USERNAME $CF_PASSWORD
 
 cf create-space -o $CF_ORGANIZATION $CF_SPACE
 cf target -o $CF_ORGANIZATION -s $CF_SPACE
-
-cleanup
 
 cf create-service ${SERVICE_NAME} ${PLAN_NAME} ${SERVICE_INSTANCE_NAME}
 
@@ -44,4 +40,5 @@ fi
 cf bind-service ${APP_NAME} ${SERVICE_INSTANCE_NAME}
 cf start ${APP_NAME}
 
-cleanup
+cf delete -f ${APP_NAME}
+cf delete-service -f ${SERVICE_INSTANCE_NAME}

--- a/pipeline.yml
+++ b/pipeline.yml
@@ -303,7 +303,6 @@ jobs:
         APP_NAME: redis28-test
         SERVICE_NAME: redis28
         PLAN_NAME: standard
-        SERVICE_INSTANCE_NAME: redis28-standard
         TEST_PATH: kubernetes-config/acceptance/redis28
     - task: acceptance-test-mongo32-standard
       file: kubernetes-config/acceptance/run-acceptance-test.yml
@@ -312,7 +311,6 @@ jobs:
         APP_NAME: mongodb32-test
         SERVICE_NAME: mongodb32
         PLAN_NAME: standard
-        SERVICE_INSTANCE_NAME: mongodb32-standard
         TEST_PATH: kubernetes-config/acceptance/mongodb32
     - task: acceptance-test-elasticsearch23-persistent
       file: kubernetes-config/acceptance/run-acceptance-test.yml
@@ -321,7 +319,6 @@ jobs:
         APP_NAME: elasticsearch23-test
         SERVICE_NAME: elasticsearch23
         PLAN_NAME: 1x
-        SERVICE_INSTANCE_NAME: elasticsearch23-1x
         TEST_PATH: kubernetes-config/acceptance/elasticsearch23
     - task: acceptance-test-elasticsearch17-persistent
       file: kubernetes-config/acceptance/run-acceptance-test.yml
@@ -330,7 +327,6 @@ jobs:
         APP_NAME: elasticsearch17-test
         SERVICE_NAME: elasticsearch17
         PLAN_NAME: 1x
-        SERVICE_INSTANCE_NAME: elasticsearch17-1x
         TEST_PATH: kubernetes-config/acceptance/elasticsearch17
     # - task: acceptance-test-mysql56-persistent
     #   file: kubernetes-config/acceptance/run-acceptance-test.yml
@@ -339,7 +335,6 @@ jobs:
     #     APP_NAME: mysql56-test
     #     SERVICE_NAME: mysql56-multinode
     #     PLAN_NAME: persistent
-    #     SERVICE_INSTANCE_NAME: mysql56-persistent
     #     TEST_PATH: kubernetes-config/acceptance/sql
     #     MANIFEST_FILE: manifest-mysql56-multinode.yml
     # - task: acceptance-test-postgresql94-persistent
@@ -349,7 +344,6 @@ jobs:
     #     APP_NAME: postgresql94-test
     #     SERVICE_NAME: postgresql94-multinode
     #     PLAN_NAME: persistent
-    #     SERVICE_INSTANCE_NAME: postgresql94-persistent
     #     TEST_PATH: kubernetes-config/acceptance/sql
     #     MANIFEST_FILE: manifest-postgresql94-multinode.yml
 
@@ -476,7 +470,6 @@ jobs:
         APP_NAME: redis28-test
         SERVICE_NAME: redis28
         PLAN_NAME: standard
-        SERVICE_INSTANCE_NAME: redis28-standard
         TEST_PATH: kubernetes-config/acceptance/redis28
     - task: acceptance-test-mongo32-standard
       file: kubernetes-config/acceptance/run-acceptance-test.yml
@@ -485,7 +478,6 @@ jobs:
         APP_NAME: mongodb32-test
         SERVICE_NAME: mongodb32
         PLAN_NAME: standard
-        SERVICE_INSTANCE_NAME: mongodb32-standard
         TEST_PATH: kubernetes-config/acceptance/mongodb32
     - task: acceptance-test-elasticsearch23-persistent
       file: kubernetes-config/acceptance/run-acceptance-test.yml
@@ -494,7 +486,6 @@ jobs:
         APP_NAME: elasticsearch23-test
         SERVICE_NAME: elasticsearch23
         PLAN_NAME: 1x
-        SERVICE_INSTANCE_NAME: elasticsearch23-1x
         TEST_PATH: kubernetes-config/acceptance/elasticsearch23
     - task: acceptance-test-elasticsearch17-persistent
       file: kubernetes-config/acceptance/run-acceptance-test.yml
@@ -503,7 +494,6 @@ jobs:
         APP_NAME: elasticsearch17-test
         SERVICE_NAME: elasticsearch17
         PLAN_NAME: 1x
-        SERVICE_INSTANCE_NAME: elasticsearch17-1x
         TEST_PATH: kubernetes-config/acceptance/elasticsearch17
     # - task: acceptance-test-mysql56-persistent
     #   file: kubernetes-config/acceptance/run-acceptance-test.yml
@@ -512,7 +502,6 @@ jobs:
     #     APP_NAME: mysql56-test
     #     SERVICE_NAME: mysql56-multinode
     #     PLAN_NAME: persistent
-    #     SERVICE_INSTANCE_NAME: mysql56-persistent
     #     TEST_PATH: kubernetes-config/acceptance/sql
     #     MANIFEST_FILE: manifest-mysql56-multinode.yml
     # - task: acceptance-test-postgresql94-persistent
@@ -522,7 +511,6 @@ jobs:
     #     APP_NAME: postgresql94-test
     #     SERVICE_NAME: postgresql94-multinode
     #     PLAN_NAME: persistent
-    #     SERVICE_INSTANCE_NAME: postgresql94-persistent
     #     TEST_PATH: kubernetes-config/acceptance/sql
     #     MANIFEST_FILE: manifest-postgresql94-multinode.yml
 


### PR DESCRIPTION
Because sometimes acceptance tests randomly fail when volume binds time out. This will prevent one random failure from breaking future acceptance test runs.