### PR TITLE
Fix tests for ES 17 and ES 23

### DIFF
--- a/acceptance/elasticsearch17/main.go
+++ b/acceptance/elasticsearch17/main.go
@@ -60,7 +60,7 @@ func main() {
 	result := Record{}
 	err = json.Unmarshal(*resp.Source, &result)
 	checkStatus(err)
-	if record.Value != "value" {
+	if result.Value != "value" {
 		log.Fatalf("incorrect value: %s", result.Value)
 	}
 

--- a/acceptance/elasticsearch23/main.go
+++ b/acceptance/elasticsearch23/main.go
@@ -60,7 +60,7 @@ func main() {
 	result := Record{}
 	err = json.Unmarshal(*resp.Source, &result)
 	checkStatus(err)
-	if record.Value != "value" {
+	if result.Value != "value" {
 		log.Fatalf("incorrect value: %s", result.Value)
 	}
 


### PR DESCRIPTION
This patch checks the `result` variable which should contain what is
returned from the index. Prior to this patch, it checked the `record`
variable which would always have Value equal to "value"