### PR TITLE
pin upstream to working version

### DIFF
--- a/manifests/kube2iam-template.yaml
+++ b/manifests/kube2iam-template.yaml
@@ -13,7 +13,7 @@ spec:
     spec:
       hostNetwork: true
       containers:
-      - image: jtblin/kube2iam:latest
+      - image: jtblin/kube2iam:0.3.1
         name: kube2iam
         args:
         - "--base-role-arn=$(BASE_ROLE_ARN)"


### PR DESCRIPTION
Until https://github.com/jtblin/kube2iam/issues/54 is resolved, revert to the known working version of kube2iam so that the logging role can be correctly passed to the fluentd containers