### PR TITLE
Revert "pin upstream to working version"

### DIFF
--- a/manifests/kube2iam-template.yaml
+++ b/manifests/kube2iam-template.yaml
@@ -13,7 +13,7 @@ spec:
     spec:
       hostNetwork: true
       containers:
-      - image: jtblin/kube2iam:0.3.1
+      - image: jtblin/kube2iam:latest
         name: kube2iam
         args:
         - "--base-role-arn=$(BASE_ROLE_ARN)"


### PR DESCRIPTION
Reverts 18F/cg-deploy-kubernetes#65

Upstream confirmed it was a defect and resolved it: https://github.com/jtblin/kube2iam/issues/54

This has been tested in staging by manually editing the daemon set and recreating the pods.