### PR TITLE
Remove GO15VENDOREXPERIMENT

### DIFF
--- a/acceptance/elasticsearch17/manifest.yml
+++ b/acceptance/elasticsearch17/manifest.yml
@@ -7,4 +7,3 @@ applications:
   memory: 128M
   env:
     GOPACKAGENAME: elasticsearch17-test
-    GO15VENDOREXPERIMENT: 1

--- a/acceptance/elasticsearch23/manifest.yml
+++ b/acceptance/elasticsearch23/manifest.yml
@@ -7,4 +7,3 @@ applications:
   memory: 128M
   env:
     GOPACKAGENAME: elasticsearch23-test
-    GO15VENDOREXPERIMENT: 1

--- a/acceptance/elasticsearch24/manifest.yml
+++ b/acceptance/elasticsearch24/manifest.yml
@@ -7,4 +7,3 @@ applications:
   memory: 128M
   env:
     GOPACKAGENAME: elasticsearch24-test
-    GO15VENDOREXPERIMENT: 1

--- a/acceptance/mongodb32/manifest.yml
+++ b/acceptance/mongodb32/manifest.yml
@@ -7,4 +7,3 @@ applications:
   memory: 128M
   env:
     GOPACKAGENAME: mongodb32-test
-    GO15VENDOREXPERIMENT: 1

--- a/acceptance/redis28/manifest.yml
+++ b/acceptance/redis28/manifest.yml
@@ -7,4 +7,3 @@ applications:
   memory: 128M
   env:
     GOPACKAGENAME: redis-test
-    GO15VENDOREXPERIMENT: 1

--- a/acceptance/sql/manifest-mysql56-multinode.yml
+++ b/acceptance/sql/manifest-mysql56-multinode.yml
@@ -7,6 +7,5 @@ applications:
   memory: 128M
   env:
     GOPACKAGENAME: sql-test
-    GO15VENDOREXPERIMENT: 1
     SQL_DRIVER: mysql
     SQL_SERVICE: mysql56-multinode

--- a/acceptance/sql/manifest-postgresql94-multinode.yml
+++ b/acceptance/sql/manifest-postgresql94-multinode.yml
@@ -7,6 +7,5 @@ applications:
   memory: 128M
   env:
     GOPACKAGENAME: sql-test
-    GO15VENDOREXPERIMENT: 1
     SQL_DRIVER: postgres
     SQL_SERVICE: postgresql94-multinode


### PR DESCRIPTION
Because:

       Run 'cf unset-env <app> GO15VENDOREXPERIMENT' before pushing again.
       **ERROR** GO15VENDOREXPERIMENT is set, but is not supported by go1.7 and later.
       **ERROR** Invalid vendor config: unsupported GO15VENDOREXPERIMENT