### PR TITLE
pin kube2iam to working version

### DIFF
--- a/manifests/kube2iam-template.yaml
+++ b/manifests/kube2iam-template.yaml
@@ -13,7 +13,7 @@ spec:
     spec:
       hostNetwork: true
       containers:
-      - image: jtblin/kube2iam:latest
+      - image: jtblin/kube2iam:0.6.2
         name: kube2iam
         args:
         - "--base-role-arn=$(BASE_ROLE_ARN)"


### PR DESCRIPTION
We need to do this until https://github.com/jtblin/kube2iam/issues/84 is fixed. 

I've already manually edited the production daemonset to use this version and it's running without error.  This PR is simply to ensure that change is not overwritten next time we deploy production k8s

