### PR TITLE
Revert kube2iam pin

### DIFF
--- a/manifests/kube2iam-template.yaml
+++ b/manifests/kube2iam-template.yaml
@@ -13,7 +13,7 @@ spec:
     spec:
       hostNetwork: true
       containers:
-      - image: jtblin/kube2iam:0.6.2
+      - image: jtblin/kube2iam:latest
         name: kube2iam
         args:
         - "--base-role-arn=$(BASE_ROLE_ARN)"


### PR DESCRIPTION
Upstream fixed this in https://github.com/jtblin/kube2iam/releases/tag/0.6.4 ( https://github.com/jtblin/kube2iam/commit/0b4a2300112a1cfa7ca703f3d204b44e54c5b77d)