### PR TITLE
enable service for all orgs not just cloud.gov

### DIFF
--- a/credentials.example.yml
+++ b/credentials.example.yml
@@ -101,7 +101,6 @@ cf-token-url-staging: CF_TOKEN_URL
 cf-token-key-staging: CF_TOKEN_KEY
 
 broker-service-names-staging: "redis28-multinode:free"
-broker-service-organization-staging: ""
 
 cf-api-url-production: https://api.your.cf.installation
 cf-deploy-username-production: USERNAME
@@ -121,7 +120,6 @@ cf-token-url-production: CF_TOKEN_URL
 cf-token-key-production: CF_TOKEN_KEY
 
 broker-service-names-production: "redis28-multinode:free"
-broker-service-organization-production: ""
 
 slack-channel: "#CHANNEL"
 slack-username: concourse

--- a/pipeline.yml
+++ b/pipeline.yml
@@ -200,7 +200,6 @@ jobs:
       AUTH_USER: {{broker-auth-user-staging}}
       AUTH_PASS: {{broker-auth-pass-staging}}
       SERVICES: {{broker-service-names-staging}}
-      SERVICE_ORGANIZATION: {{broker-service-organization-staging}}
 
 - name: acceptance-tests-staging
   serial: true
@@ -374,7 +373,6 @@ jobs:
       AUTH_USER: {{broker-auth-user-production}}
       AUTH_PASS: {{broker-auth-pass-production}}
       SERVICES: {{broker-service-names-production}}
-      SERVICE_ORGANIZATION: {{broker-service-organization-production}}
 
 - name: acceptance-tests-production
   serial: true


### PR DESCRIPTION
The pipeline was incorrectly configured to only enable services for the cloud.gov org.  This removes that setting so the services configured in the pipeline are made available to all orgs.

The pipeline only enables redis and es24 1/3/6x; other specialized plans are still enabled for specific orgs manually.

