### PR TITLE
Http acceptance tests

### DIFF
--- a/acceptance/elasticsearch24/glide.lock
+++ b/acceptance/elasticsearch24/glide.lock
@@ -1,17 +1,17 @@
-hash: 61d5e270d1a33c2ad83ff98ebbd41d89c69cf542972fc3792f6ba4fe6cb247c5
-updated: 2016-09-01T12:00:00.070880165-04:00
+hash: 82e52bca40a14b171e928b38c98678210ddd4904ca9639e63afe051c4924d39b
+updated: 2017-07-14T18:19:04.691502256-04:00
 imports:
 - name: github.com/cloudfoundry-community/go-cfenv
-  version: 96ad7376813bfd13c95af69ca5b4ef5725f6b335
+  version: f920e9562d5f951cbf11785728f67258c38a10d0
 - name: github.com/mitchellh/mapstructure
-  version: ca63d7c062ee3c9f34db231e352b60012b4fd0c1
+  version: d0303fe809921458f417bcf828397a65db30a7e4
 - name: golang.org/x/net
-  version: 1358eff22f0dd0c54fc521042cc607f6ff4b531a
+  version: f01ecb60fe3835d80d9a0b7b2bf24b228c89260e
   subpackages:
   - context
   - context/ctxhttp
 - name: gopkg.in/olivere/elastic.v3
-  version: f9fd15e1ea3a50bbe58c72a4b8820499fe3bb0e1
+  version: 5a75b7d18bca7420e68338600e8c9f611435f911
   subpackages:
   - backoff
   - uritemplates

--- a/acceptance/elasticsearch24/glide.yaml
+++ b/acceptance/elasticsearch24/glide.yaml
@@ -1,6 +1,6 @@
 package: elasticsearch24-test
 import:
 - package: github.com/cloudfoundry-community/go-cfenv
-  version: ~1.14.0
+  version: ~1.17.0
 - package: gopkg.in/olivere/elastic.v3
   version: ~3.0.50

--- a/acceptance/elasticsearch24/manifest.yml
+++ b/acceptance/elasticsearch24/manifest.yml
@@ -2,8 +2,6 @@ applications:
 - name: elasticsearch24-test
   buildpack: go_buildpack
   command: elasticsearch24-test
-  health-check-type: none
-  no-route: true
   memory: 128M
   env:
     GOPACKAGENAME: elasticsearch24-test

--- a/acceptance/mongodb32/glide.lock
+++ b/acceptance/mongodb32/glide.lock
@@ -1,15 +1,15 @@
-hash: 786dbb160fd2feedcdd18bb83facf27d213d65a9ba3c96a4f29053c85085952d
-updated: 2016-08-29T19:24:37.459673931-04:00
+hash: 1b0e9e83d385f1326f8d07cc6369ba3902e5cf9e1e040cc79cbe61cd6e5b3878
+updated: 2017-07-14T18:59:56.614715554-04:00
 imports:
 - name: github.com/cloudfoundry-community/go-cfenv
-  version: 96ad7376813bfd13c95af69ca5b4ef5725f6b335
+  version: f920e9562d5f951cbf11785728f67258c38a10d0
 - name: github.com/mitchellh/mapstructure
-  version: ca63d7c062ee3c9f34db231e352b60012b4fd0c1
+  version: d0303fe809921458f417bcf828397a65db30a7e4
 - name: gopkg.in/mgo.v2
   version: 3f83fa5005286a7fe593b055f0d7771a7dce4655
   subpackages:
   - bson
+  - internal/json
   - internal/sasl
   - internal/scram
-  - internal/json
 testImports: []

--- a/acceptance/mongodb32/glide.yaml
+++ b/acceptance/mongodb32/glide.yaml
@@ -1,7 +1,7 @@
 package: mongodb32-test
 import:
 - package: github.com/cloudfoundry-community/go-cfenv
-  version: ~1.14.0
+  version: ~1.17.0
 - package: gopkg.in/mgo.v2
   subpackages:
   - bson

--- a/acceptance/mongodb32/main.go
+++ b/acceptance/mongodb32/main.go
@@ -1,10 +1,11 @@
 package main
 
 import (
+	"encoding/json"
 	"fmt"
 	"log"
+	"net/http"
 	"os"
-	"os/signal"
 
 	"github.com/cloudfoundry-community/go-cfenv"
 	"gopkg.in/mgo.v2"
@@ -17,16 +18,46 @@ func checkStatus(err error) {
 	}
 }
 
-func waitForExit() {
-	c := make(chan os.Signal, 1)
-	signal.Notify(c, os.Interrupt, os.Kill)
-	<-c
-	os.Exit(0)
+func writeError(w http.ResponseWriter, err error) {
+	message, _ := json.Marshal(map[string]string{
+		"error": err.Error(),
+	})
+	w.Write(message)
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusInternalServerError)
 }
 
 type Record struct {
 	Key   string
 	Value string
+}
+
+var client *mgo.Collection
+
+func handler(w http.ResponseWriter, r *http.Request) {
+	// Set and check document
+	err := client.Insert(&Record{Key: "test", Value: "test"})
+	if err != nil {
+		writeError(w, err)
+		return
+	}
+
+	result := Record{}
+	err = client.Find(bson.M{"key": "test"}).One(&result)
+	if err != nil {
+		writeError(w, err)
+		return
+	}
+	if result.Value != "test" {
+		writeError(w, fmt.Errorf("incorrect value: %s", result.Value))
+		return
+	}
+
+	err = client.Remove(bson.M{"key": "test"})
+	if err != nil {
+		writeError(w, err)
+		return
+	}
 }
 
 func main() {
@@ -43,19 +74,9 @@ func main() {
 	checkStatus(err)
 	defer session.Close()
 
-	client := session.DB(fmt.Sprint(creds["dbname"])).C("test")
+	client = session.DB(fmt.Sprint(creds["dbname"])).C("test")
 
-	// Set and check document
-	checkStatus(client.Insert(&Record{Key: "test", Value: "test"}))
-
-	result := Record{}
-	checkStatus(client.Find(bson.M{"key": "test"}).One(&result))
-	if result.Value != "test" {
-		log.Fatalf("incorrect value: %s", result.Value)
-	}
-
-	checkStatus(client.Remove(bson.M{"key": "test"}))
-
-	// Keep alive
-	waitForExit()
+	// Serve HTTP
+	http.HandleFunc("/", handler)
+	log.Fatal(http.ListenAndServe(fmt.Sprintf(":%s", os.Getenv("PORT")), nil))
 }

--- a/acceptance/mongodb32/manifest.yml
+++ b/acceptance/mongodb32/manifest.yml
@@ -2,8 +2,6 @@ applications:
 - name: mongodb32-test
   buildpack: go_buildpack
   command: mongodb32-test
-  health-check-type: none
-  no-route: true
   memory: 128M
   env:
     GOPACKAGENAME: mongodb32-test

--- a/acceptance/redis28/glide.lock
+++ b/acceptance/redis28/glide.lock
@@ -1,13 +1,13 @@
-hash: 58bcd47b7b1fb21cabfd823746a6b5f7e093a6491bf4338b24e09bca70ee8f6e
-updated: 2016-08-29T19:23:53.655169671-04:00
+hash: 2dd408a5a6176ab3f127531c15c13e387ace41a8623c9249276a0db4208308e6
+updated: 2017-07-14T19:20:45.6554319-04:00
 imports:
 - name: github.com/cloudfoundry-community/go-cfenv
-  version: 96ad7376813bfd13c95af69ca5b4ef5725f6b335
+  version: f920e9562d5f951cbf11785728f67258c38a10d0
 - name: github.com/garyburd/redigo
-  version: 8873b2f1995f59d4bcdd2b0dc9858e2cb9bf0c13
+  version: 433969511232c397de61b1442f9fd49ec06ae9ba
   subpackages:
-  - redis
   - internal
+  - redis
 - name: github.com/mitchellh/mapstructure
-  version: ca63d7c062ee3c9f34db231e352b60012b4fd0c1
+  version: d0303fe809921458f417bcf828397a65db30a7e4
 testImports: []

--- a/acceptance/redis28/glide.yaml
+++ b/acceptance/redis28/glide.yaml
@@ -1,8 +1,8 @@
 package: redis-test
 import:
 - package: github.com/cloudfoundry-community/go-cfenv
-  version: ~1.14.0
+  version: ~1.17.0
 - package: github.com/garyburd/redigo
-  version: ~1.0.0
+  version: ~1.1.0
   subpackages:
   - redis

--- a/acceptance/redis28/manifest.yml
+++ b/acceptance/redis28/manifest.yml
@@ -2,8 +2,6 @@ applications:
 - name: redis28-test
   buildpack: go_buildpack
   command: redis-test
-  health-check-type: none
-  no-route: true
   memory: 128M
   env:
     GOPACKAGENAME: redis-test

--- a/infrastructure-aws-development.yml
+++ b/infrastructure-aws-development.yml
@@ -1,0 +1,13 @@
+instance_groups:
+- name: master
+  jobs:
+  - name: kubernetes-minion
+    properties:
+      aws:
+        cluster-tag: kubernetes-development
+- name: minion
+  jobs:
+  - name: kubernetes-minion
+    properties:
+      aws:
+        cluster-tag: kubernetes-development

--- a/manifests/riemann-podstatus-template.yaml
+++ b/manifests/riemann-podstatus-template.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1beta1
 kind: Deployment
 metadata:
   name: riemann-podstatus

--- a/manifests/storage-class.yaml
+++ b/manifests/storage-class.yaml
@@ -1,6 +1,6 @@
 ---
 kind: StorageClass
-apiVersion: storage.k8s.io/v1beta1
+apiVersion: storage.k8s.io/v1
 metadata:
   name: default
 provisioner: kubernetes.io/aws-ebs

--- a/pipeline.yml
+++ b/pipeline.yml
@@ -91,17 +91,14 @@ params:
       BOSH_CACERT: common/master-bosh.crt
   acceptance:
     redis28-tests: &redis28-tests
-      APP_NAME: redis28-test
       SERVICE_NAME: redis28
       PLAN_NAME: standard
       TEST_PATH: kubernetes-config/acceptance/redis28
     mongodb32-tests: &mongodb32-tests
-      APP_NAME: mongodb32-test
       SERVICE_NAME: mongodb32
       PLAN_NAME: standard
       TEST_PATH: kubernetes-config/acceptance/mongodb32
     elasticsearch24-tests: &elasticsearch24-tests
-      APP_NAME: elasticsearch24-test
       SERVICE_NAME: elasticsearch24
       PLAN_NAME: 1x
       TEST_PATH: kubernetes-config/acceptance/elasticsearch24

--- a/pipeline.yml
+++ b/pipeline.yml
@@ -14,22 +14,26 @@ groups:
   - deploy-kubernetes-production
   - deploy-kubernetes-broker-production
   - acceptance-tests-production
-- name: release
-  jobs:
-  - fluentd-cloudwatch
-  - elasticsearch-24
-  - mongo-32
-- name: deploy
+- name: development
   jobs:
   - deploy-kubernetes-development
   - deploy-kubernetes-broker-development
   - acceptance-tests-development
+- name: staging
+  jobs:
   - deploy-kubernetes-staging
   - deploy-kubernetes-broker-staging
   - acceptance-tests-staging
+- name: production
+  jobs:
   - deploy-kubernetes-production
   - deploy-kubernetes-broker-production
   - acceptance-tests-production
+- name: docker-images
+  jobs:
+  - fluentd-cloudwatch
+  - elasticsearch-24
+  - mongo-32
 
 params:
   development:

--- a/pipeline.yml
+++ b/pipeline.yml
@@ -135,9 +135,11 @@ jobs:
       resource: master-bosh-root-cert
     - get: pipeline-tasks
     - get: kubernetes-release
+      resource: kubernetes-release-development
       params:
         submodules: none
     - get: kubernetes-config
+      resource: kubernetes-config-development
       trigger: true
     - get: kubernetes-release-tarball
       resource: kubernetes-release-tarball-development
@@ -215,8 +217,10 @@ jobs:
   - aggregate:
     - get: pipeline-tasks
     - get: kubernetes-broker
+      resource: kubernetes-broker-development
       trigger: true
     - get: kubernetes-config
+      resource: kubernetes-config-development
       passed: [deploy-kubernetes-development]
     - get: kubernetes-development-deployment
       passed: [deploy-kubernetes-development]
@@ -255,9 +259,11 @@ jobs:
   plan:
   - aggregate:
     - get: kubernetes-config
+      resource: kubernetes-config-development
       passed: [deploy-kubernetes-broker-development]
       trigger: true
     - get: kubernetes-broker
+      resource: kubernetes-broker-development
       passed: [deploy-kubernetes-broker-development]
       trigger: true
   - aggregate:
@@ -588,17 +594,35 @@ resources:
     uri: {{kubernetes-release-git-url}}
     branch: {{kubernetes-release-git-branch}}
 
+- name: kubernetes-release-development
+  type: git
+  source:
+    uri: {{kubernetes-release-development-git-url}}
+    branch: {{kubernetes-release-development-git-branch}}
+
 - name: kubernetes-broker
   type: git
   source:
     uri: {{kubernetes-broker-git-url}}
     branch: {{kubernetes-broker-git-branch}}
 
+- name: kubernetes-broker-development
+  type: git
+  source:
+    uri: {{kubernetes-broker-development-git-url}}
+    branch: {{kubernetes-broker-development-git-branch}}
+
 - name: kubernetes-config
   type: git
   source:
     uri: {{kubernetes-config-git-url}}
     branch: {{kubernetes-config-git-branch}}
+
+- name: kubernetes-config-development
+  type: git
+  source:
+    uri: {{kubernetes-config-development-git-url}}
+    branch: {{kubernetes-config-development-git-branch}}
 
 - name: kubernetes-stemcell
   type: bosh-io-stemcell

--- a/pipeline.yml
+++ b/pipeline.yml
@@ -159,7 +159,7 @@ jobs:
       CLOUDWATCH_PARAMS: {{cloudwatch-params-development}}
       KUBE2IAM_PARAMS: {{kube2iam-params-development}}
       RIEMANN_PODSTATUS_PARAMS: {{riemann-podstatus-params-development}}
-      TARGET_ENVIRONMENT: staging
+      TARGET_ENVIRONMENT: development
   - &lint-manifest
     task: lint-manifest
     file: pipeline-tasks/lint-manifest.yml


### PR DESCRIPTION
So that the tests fail when they should 😓. Currently, test apps run with a process health check, which means cf only verifies that they start successfully and doesn't notice if they crash later. This patch refactors tests to run tiny web apps that we query via http, so we can verify that the apps can actually talk to k8s services.

To verify: introduce a bug into one of the test apps, push the app, and make sure a request to `/` fails.