### PR TITLE
[ work in progress ] Add three more instances for k8s minions

### DIFF
--- a/k8s-jobs.yml
+++ b/k8s-jobs.yml
@@ -77,7 +77,7 @@ instance_groups:
         ip: (( grab instance_groups.etcd.networks.services.static_ips.[0] ))
 
 - name: minion
-  instances: 5
+  instances: 8
   persistent_disk_type: kubernetes
   vm_extensions: [kubernetes-sg, kubernetes-minion-profile]
   networks:


### PR DESCRIPTION
This is a [wip] branch until we figure out what a good number of instances should be for k8s. This is tied to Redis HA and ES HA. This is a temporary fix until we research out the underling problem a bit.