### PR TITLE
[ work in progress ] Put the [ip]masq on, put the [ip]masq off

### DIFF
--- a/k8s-jobs.yml
+++ b/k8s-jobs.yml
@@ -97,7 +97,7 @@ instance_groups:
         log_options: [max-size=10m, max-file=1]
   - name: flannel
     properties:
-      ip_masq: false
+      ip_masq: true
       apiserver:
         ip: (( grab instance_groups.etcd.networks.services.static_ips.[0] ))
   - name: cron

--- a/k8s-jobs.yml
+++ b/k8s-jobs.yml
@@ -92,10 +92,12 @@ instance_groups:
   - name: docker
     properties:
       docker:
+        ip_masq: false
         flannel: true
         log_options: [max-size=10m, max-file=1]
   - name: flannel
     properties:
+      ip_masq: false
       apiserver:
         ip: (( grab instance_groups.etcd.networks.services.static_ips.[0] ))
   - name: cron


### PR DESCRIPTION
@linuxbozo and I ran into [this issue](https://stackoverflow.com/a/37411969) during our Redis HA story. We're modifying the cloudfoundry-community/docker-boshrelease to add support for disabling and enabling the `ip_masq` property for docker and flannel.