### PR TITLE
Drop allocatable resources and evict pods on low resources.

### DIFF
--- a/k8s-jobs.yml
+++ b/k8s-jobs.yml
@@ -98,6 +98,9 @@ instance_groups:
     properties:
       apiserver:
         ip: (( grab instance_groups.etcd.networks.services.static_ips.[0] ))
+  - name: kubernetes-minion
+    properties:
+      eviction-hard: memory.available<2Gi
   - name: cron
     release: cron
     properties:


### PR DESCRIPTION
This will probably need to be tuned, but this seems like a reasonable place to start based on conversation in slack.