### PR TITLE
Add redis32 tests

### DIFF
--- a/acceptance/redis32/glide.lock
+++ b/acceptance/redis32/glide.lock
@@ -1,0 +1,13 @@
+hash: 2dd408a5a6176ab3f127531c15c13e387ace41a8623c9249276a0db4208308e6
+updated: 2017-07-14T19:20:45.6554319-04:00
+imports:
+- name: github.com/cloudfoundry-community/go-cfenv
+  version: f920e9562d5f951cbf11785728f67258c38a10d0
+- name: github.com/garyburd/redigo
+  version: 433969511232c397de61b1442f9fd49ec06ae9ba
+  subpackages:
+  - internal
+  - redis
+- name: github.com/mitchellh/mapstructure
+  version: d0303fe809921458f417bcf828397a65db30a7e4
+testImports: []

--- a/acceptance/redis32/glide.yaml
+++ b/acceptance/redis32/glide.yaml
@@ -1,0 +1,8 @@
+package: redis-test
+import:
+- package: github.com/cloudfoundry-community/go-cfenv
+  version: ~1.17.0
+- package: github.com/garyburd/redigo
+  version: ~1.1.0
+  subpackages:
+  - redis

--- a/acceptance/redis32/main.go
+++ b/acceptance/redis32/main.go
@@ -13,6 +13,9 @@ import (
 	"github.com/garyburd/redigo/redis"
 )
 
+var client redis.Conn
+var pool *redis.Pool
+
 func checkStatus(err error) {
 	if err != nil {
 		log.Fatalf("error: %s", err.Error())
@@ -32,7 +35,7 @@ func newPool(addr string, password string) *redis.Pool {
 	return &redis.Pool{
 		MaxIdle:     3,
 		MaxActive:   10,
-		IdleTimeout: 2 * time.Second,
+		IdleTimeout: 1 * time.Second,
 		Dial: func() (redis.Conn, error) {
 			c, err := redis.Dial("tcp", addr)
 			if err != nil {
@@ -54,9 +57,6 @@ func newPool(addr string, password string) *redis.Pool {
 		},
 	}
 }
-
-var client redis.Conn
-var pool *redis.Pool
 
 func testSetGetDelete(w http.ResponseWriter, r *http.Request) {
 	client = pool.Get()

--- a/acceptance/redis32/main.go
+++ b/acceptance/redis32/main.go
@@ -131,16 +131,16 @@ func configGet(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	w.WriteHeader(http.StatusOK)
+	jresp, err := json.Marshal(primaryConfig)
 
-	if parameter == "*" {
-		jresp, _ := json.Marshal(primaryConfig)
-		w.Header().Set("Content-Type", "application/json")
-		w.Write(jresp)
-	} else {
-		w.Header().Set("Content-Type", "text/plain")
-		w.Write([]byte(primaryConfig[parameter]))
+	if err != nil {
+		writeError(w, err)
+		return
 	}
+
+	w.WriteHeader(http.StatusOK)
+	w.Header().Set("Content-Type", "application/json")
+	w.Write(jresp)
 
 }
 

--- a/acceptance/redis32/main.go
+++ b/acceptance/redis32/main.go
@@ -1,0 +1,77 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+
+	"github.com/cloudfoundry-community/go-cfenv"
+	"github.com/garyburd/redigo/redis"
+)
+
+func checkStatus(err error) {
+	if err != nil {
+		log.Fatalf("error: %s", err.Error())
+	}
+}
+
+func writeError(w http.ResponseWriter, err error) {
+	message, _ := json.Marshal(map[string]string{
+		"error": err.Error(),
+	})
+	w.Write(message)
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusInternalServerError)
+}
+
+var client redis.Conn
+
+func handler(w http.ResponseWriter, r *http.Request) {
+	// Set and check value
+	_, err := client.Do("SET", "test", "test")
+	if err != nil {
+		writeError(w, err)
+		return
+	}
+
+	value, err := redis.String(client.Do("GET", "test"))
+	if err != nil {
+		writeError(w, err)
+		return
+	}
+	if value != "test" {
+		writeError(w, fmt.Errorf("incorrect value: %s", value))
+		return
+	}
+
+	_, err = client.Do("DEL", "test")
+	if err != nil {
+		writeError(w, err)
+		return
+	}
+}
+
+func main() {
+	// Get redis32-multinode credentials
+	env, _ := cfenv.Current()
+	services, _ := env.Services.WithLabel("redis32")
+	if len(services) != 1 {
+		log.Fatal("redis32 service not found")
+	}
+	creds := services[0].Credentials
+
+	// Create redis client
+	var err error
+	client, err = redis.Dial("tcp", fmt.Sprintf("%s:%s", creds["hostname"], creds["port"]))
+	checkStatus(err)
+	defer client.Close()
+
+	_, err = client.Do("AUTH", creds["password"].(string))
+	checkStatus(err)
+
+	// Serve HTTP
+	http.HandleFunc("/", handler)
+	log.Fatal(http.ListenAndServe(fmt.Sprintf(":%s", os.Getenv("PORT")), nil))
+}

--- a/acceptance/redis32/main.go
+++ b/acceptance/redis32/main.go
@@ -35,7 +35,7 @@ func newPool(addr string, password string) *redis.Pool {
 	return &redis.Pool{
 		MaxIdle:     3,
 		MaxActive:   10,
-		IdleTimeout: 1 * time.Second,
+		IdleTimeout: 250 * time.Millisecond
 		Dial: func() (redis.Conn, error) {
 			c, err := redis.Dial("tcp", addr)
 			if err != nil {
@@ -61,7 +61,7 @@ func newPool(addr string, password string) *redis.Pool {
 
 func testSetGetDelete(w http.ResponseWriter, r *http.Request) {
 	client = pool.Get()
-	defer client.Close()
+
 	log.Printf("active connections: %d", pool.ActiveCount())
 	// Set and check value
 	_, err := client.Do("SET", "test", "test")
@@ -87,11 +87,12 @@ func testSetGetDelete(w http.ResponseWriter, r *http.Request) {
 	}
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
+
+	client.Close()
 }
 
 func info(w http.ResponseWriter, r *http.Request) {
 	client = pool.Get()
-	defer client.Close()
 
 	parameter := r.URL.Query().Get("s")
 
@@ -126,11 +127,11 @@ func info(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusOK)
 	w.Write(jresp)
 
+	client.Close()
 }
 
 func configGet(w http.ResponseWriter, r *http.Request) {
 	client = pool.Get()
-	defer client.Close()
 
 	parameter := r.URL.Query().Get("p")
 
@@ -156,6 +157,7 @@ func configGet(w http.ResponseWriter, r *http.Request) {
 		w.Write([]byte(primaryConfig[parameter]))
 	}
 
+	client.Close()
 }
 
 func main() {

--- a/acceptance/redis32/main.go
+++ b/acceptance/redis32/main.go
@@ -35,7 +35,7 @@ func newPool(addr string, password string) *redis.Pool {
 	return &redis.Pool{
 		MaxIdle:     3,
 		MaxActive:   10,
-		IdleTimeout: 250 * time.Millisecond
+		IdleTimeout: 250 * time.Millisecond,
 		Dial: func() (redis.Conn, error) {
 			c, err := redis.Dial("tcp", addr)
 			if err != nil {

--- a/acceptance/redis32/main.go
+++ b/acceptance/redis32/main.go
@@ -21,6 +21,7 @@ func checkStatus(err error) {
 }
 
 func writeError(w http.ResponseWriter, err error) {
+	log.Printf("There was an error, %s\n", err.Error())
 	message, _ := json.Marshal(map[string]string{
 		"error": err.Error(),
 	})

--- a/acceptance/redis32/main.go
+++ b/acceptance/redis32/main.go
@@ -12,8 +12,6 @@ import (
 	"github.com/garyburd/redigo/redis"
 )
 
-var client redis.Conn
-
 func checkStatus(err error) {
 	if err != nil {
 		log.Fatalf("error: %s", err.Error())
@@ -48,7 +46,7 @@ func newConnection() redis.Conn {
 }
 
 func testSetGetDelete(w http.ResponseWriter, r *http.Request) {
-	client = newConnection()
+	client := newConnection()
 	defer client.Close()
 
 	// Set and check value
@@ -79,7 +77,7 @@ func testSetGetDelete(w http.ResponseWriter, r *http.Request) {
 }
 
 func info(w http.ResponseWriter, r *http.Request) {
-	client = newConnection()
+	client := newConnection()
 	defer client.Close()
 
 	parameter := r.URL.Query().Get("s")
@@ -118,7 +116,7 @@ func info(w http.ResponseWriter, r *http.Request) {
 }
 
 func configGet(w http.ResponseWriter, r *http.Request) {
-	client = newConnection()
+	client := newConnection()
 	defer client.Close()
 
 	parameter := r.URL.Query().Get("p")

--- a/acceptance/redis32/main.go
+++ b/acceptance/redis32/main.go
@@ -48,7 +48,8 @@ func newPool(addr string, password string) *redis.Pool {
 			return c, nil
 		},
 		TestOnBorrow: func(c redis.Conn, t time.Time) error {
-			threshold := 5 * time.Second
+			fmt.Printf("running TestOnBorrow, %#v\n", t)
+			threshold := 250 * time.Millisecond
 			if time.Since(t) < threshold {
 				return nil
 			}

--- a/acceptance/redis32/main.go
+++ b/acceptance/redis32/main.go
@@ -71,9 +71,8 @@ func testSetGetDelete(w http.ResponseWriter, r *http.Request) {
 		writeError(w, err)
 		return
 	}
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(http.StatusOK)
 
+	w.WriteHeader(http.StatusOK)
 }
 
 func info(w http.ResponseWriter, r *http.Request) {

--- a/acceptance/redis32/main.go
+++ b/acceptance/redis32/main.go
@@ -48,6 +48,7 @@ func newConnection() redis.Conn {
 
 func testSetGetDelete(w http.ResponseWriter, r *http.Request) {
 	client = newConnection()
+	defer client.Close()
 
 	// Set and check value
 	_, err := client.Do("SET", "test", "test")
@@ -74,11 +75,11 @@ func testSetGetDelete(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
 
-	client.Close()
 }
 
 func info(w http.ResponseWriter, r *http.Request) {
 	client = newConnection()
+	defer client.Close()
 
 	parameter := r.URL.Query().Get("s")
 
@@ -113,11 +114,11 @@ func info(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusOK)
 	w.Write(jresp)
 
-	client.Close()
 }
 
 func configGet(w http.ResponseWriter, r *http.Request) {
 	client = newConnection()
+	defer client.Close()
 
 	parameter := r.URL.Query().Get("p")
 
@@ -143,7 +144,6 @@ func configGet(w http.ResponseWriter, r *http.Request) {
 		w.Write([]byte(primaryConfig[parameter]))
 	}
 
-	client.Close()
 }
 
 func main() {

--- a/acceptance/redis32/main.go
+++ b/acceptance/redis32/main.go
@@ -13,7 +13,6 @@ import (
 )
 
 var client redis.Conn
-var pool *redis.Pool
 
 func checkStatus(err error) {
 	if err != nil {
@@ -50,7 +49,6 @@ func newConnection() redis.Conn {
 func testSetGetDelete(w http.ResponseWriter, r *http.Request) {
 	client = newConnection()
 
-	log.Printf("active connections: %d", pool.ActiveCount())
 	// Set and check value
 	_, err := client.Do("SET", "test", "test")
 	if err != nil {

--- a/acceptance/redis32/main.go
+++ b/acceptance/redis32/main.go
@@ -114,7 +114,12 @@ func info(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	jresp, _ := json.Marshal(infoMap)
+	jresp, err := json.Marshal(infoMap)
+
+	if err != nil {
+		writeError(w, err)
+		return
+	}
 
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)

--- a/acceptance/redis32/main.go
+++ b/acceptance/redis32/main.go
@@ -110,7 +110,7 @@ func info(w http.ResponseWriter, r *http.Request) {
 	for _, line := range strings.Split(infoString, "\r\n") {
 		part := strings.Split(line, ":")
 		if len(part) == 2 {
-			infoMap[string(part[0])] = string(part[1])
+			infoMap[part[0]] = part[1]
 		}
 	}
 

--- a/acceptance/redis32/manifest.yml
+++ b/acceptance/redis32/manifest.yml
@@ -1,0 +1,7 @@
+applications:
+- name: redis28-test
+  buildpack: go_buildpack
+  command: redis-test
+  memory: 128M
+  env:
+    GOPACKAGENAME: redis-test

--- a/acceptance/redis32/manifest.yml
+++ b/acceptance/redis32/manifest.yml
@@ -1,5 +1,5 @@
 applications:
-- name: redis28-test
+- name: redis32-test
   buildpack: go_buildpack
   command: redis-test
   memory: 128M

--- a/acceptance/redis32/redis-ha.sh
+++ b/acceptance/redis32/redis-ha.sh
@@ -14,7 +14,7 @@ run_tests() {
 # Get all pods from Kubernetes matching $idx_and_short_serviceid
 get_k8s_pods() {
   curl -G -ksf -u"${K8S_USERNAME}:${K8S_PASSWORD}" "${K8S_APISERVER}/api/v1/namespaces/default/pods?labelSelector=idx_and_short_serviceid%3D${idx_and_short_serviceid}" | \
-  jq '.items[] | { name: .metadata.name, node: .status.hostIP, ip: .status.podIP, status: .status.phase }' \ |
+  jq '.items[] | { name: .metadata.name, node: .status.hostIP, ip: .status.podIP, status: .status.phase }' | \
   jq -s '.'
 }
 

--- a/acceptance/redis32/redis-ha.sh
+++ b/acceptance/redis32/redis-ha.sh
@@ -20,7 +20,7 @@ get_k8s_pods() {
 
 # Get the current primary server's IP address
 get_primary_ip() {
-  curl -kfs "https://${url}/config-get?p=slave-announce-ip"
+  curl -kfs "https://${url}/config-get?p=slave-announce-ip" | jq -re '.["slave-announce-ip"]'
 }
 
 # Get the current primary server's role

--- a/acceptance/redis32/redis-ha.sh
+++ b/acceptance/redis32/redis-ha.sh
@@ -45,7 +45,7 @@ check_number_of_replicas() {
       echo "The proxy isn't connected to the master. This shouldn't happen"
       return 1
     fi
-    if [ $(($(get_replica_count) + 0)) -lt 2 ]
+    if [ $(($(get_replica_count) + 0)) -lt $replica_count ]
     then
       let counter-=1
       sleep 5
@@ -55,6 +55,8 @@ check_number_of_replicas() {
   done
   return 1
 }
+
+export replica_count=$(($(get_replica_count) + 0))
 
 run_tests
 

--- a/acceptance/redis32/redis-ha.sh
+++ b/acceptance/redis32/redis-ha.sh
@@ -25,7 +25,7 @@ get_primary_ip() {
 
 # Get the current primary server's role
 get_primary_role() {
-  curl -kfv "https://${url}/info?s=replication" | jq -re ".role"
+  curl -kfs "https://${url}/info?s=replication" | jq -re ".role"
 }
 
 # Get the number of replicas that the primary server knows about

--- a/acceptance/redis32/redis-ha.sh
+++ b/acceptance/redis32/redis-ha.sh
@@ -40,11 +40,11 @@ check_number_of_replicas() {
   counter=120
   until [ $counter -le 0 ]
   do
-    if [[ $(get_primary_role) != "master" ]]
-    then
-      echo "The proxy isn't connected to the master. This shouldn't happen"
-      return 1
-    fi
+    #if [[ $(get_primary_role) != "master" ]]
+    #then
+      #echo "The proxy isn't connected to the master. This shouldn't happen"
+      #return 1
+    #fi
     if [ $(get_replica_count) -lt 2 ]
     then
       let counter-=1

--- a/acceptance/redis32/redis-ha.sh
+++ b/acceptance/redis32/redis-ha.sh
@@ -40,11 +40,11 @@ check_number_of_replicas() {
   counter=120
   until [ $counter -le 0 ]
   do
-    #if [[ $(get_primary_role) != "master" ]]
-    #then
-      #echo "The proxy isn't connected to the master. This shouldn't happen"
-      #return 1
-    #fi
+    if [[ $(get_primary_role) != "master" ]]
+    then
+      echo "The proxy isn't connected to the master. This shouldn't happen"
+      return 1
+    fi
     if [ $(($(get_replica_count) + 0)) -lt 2 ]
     then
       let counter-=1

--- a/acceptance/redis32/redis-ha.sh
+++ b/acceptance/redis32/redis-ha.sh
@@ -20,8 +20,7 @@ get_k8s_pods() {
 
 # Get the current primary server's IP address
 get_primary_ip() {
-  curl -kfs "https://${url}/config-get?p=slave-announce-ip" | \
-  jq -re '."slave-announce-ip"'
+  curl -kfs "https://${url}/config-get?p=slave-announce-ip"
 }
 
 # Get the current primary server's role

--- a/acceptance/redis32/redis-ha.sh
+++ b/acceptance/redis32/redis-ha.sh
@@ -77,6 +77,9 @@ curl -ks -u"${K8S_USERNAME}:${K8S_PASSWORD}" \
   "${K8S_APISERVER}/api/v1/namespaces/default/pods/${primary_server_name}" \
   -XDELETE
 
+# Wait for Sentinels to elect a new primaryserver
+sleep 15
+
 if ! check_number_of_replicas
 then
   echo "Number of servers never hit 3x"

--- a/acceptance/redis32/redis-ha.sh
+++ b/acceptance/redis32/redis-ha.sh
@@ -25,21 +25,16 @@ get_primary_ip() {
 
 # Get the current primary server's role
 get_primary_role() {
-  curl -kfs "https://${url}/info?s=replication" | \
-  jq -re ".role"
+  curl -kfv "https://${url}/info?s=replication" | jq -re ".role"
 }
 
 # Get the number of replicas that the primary server knows about
 get_replica_count() {
-  curl -kfs "https://${url}/info?s=replication" | \
-  jq -re '.connected_slaves'
+  curl -kfs "https://${url}/info?s=replication" | jq -re '.connected_slaves'
 }
 
 # Iterate on number of replicas to verify that we're at 3x servers
 check_number_of_replicas() {
-  echo "Sleeping for 1 min; do your debugging now!"
-  echo "try running => curl -kfs 'https://${url}/info?s=replication' | jq -re '.role'"
-  sleep 60
   counter=120
   until [ $counter -le 0 ]
   do

--- a/acceptance/redis32/redis-ha.sh
+++ b/acceptance/redis32/redis-ha.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+
+set -xue
+
+# run a few tests
+
+# destroy server/0 via k8s API
+
+sleep 5
+
+# run a few tests
+
+# destroy server/0 & server/0 via k8s API
+
+sleep 10
+
+# run a few tests
+
+# destroy all servers via k8s API
+
+sleep 20
+
+# run a few tests
+
+# Destroy a random sentinel
+
+sleep 10
+
+# run a few tests
+
+# destroy a random proxy via k8s API
+
+sleep 5
+
+# run a few tests

--- a/acceptance/redis32/redis-ha.sh
+++ b/acceptance/redis32/redis-ha.sh
@@ -3,6 +3,11 @@
 
 set -xue
 
+
+# get all pods by service_id
+curl -ks -u"${K8S_USERNAME}:${K8S_PASSWORD}" "${K8S_APISERVER}/api/v1/namespaces/default/pods/" | \
+jq '.items[] | select( .metadata.name | test( "'"${SERVICE_ID}"'" ) ) | { name: .metadata.name, node: .status.hostIP, ip: .status.podIP }'
+
 # run a few tests
 
 # destroy server/0 via k8s API

--- a/acceptance/redis32/redis-ha.sh
+++ b/acceptance/redis32/redis-ha.sh
@@ -4,7 +4,7 @@ set -xe
 
 # Test Redis is working by running `SET`, `GET`, and `DEL`.
 run_tests() {
-  if $(curl -kfs "https://${url}/")
+  if ! $(curl -kfs "https://${url}/")
   then
     echo "error with testing Redis."
     exit 99

--- a/acceptance/redis32/redis-ha.sh
+++ b/acceptance/redis32/redis-ha.sh
@@ -40,12 +40,12 @@ check_number_of_replicas() {
   counter=120
   until [ $counter -le 0 ]
   do
-    #if [[ $(get_primary_role) != "master" ]]
+    #if [[ get_primary_role != "master" ]]
     #then
       #echo "The proxy isn't connected to the master. This shouldn't happen"
       #return 1
     #fi
-    if [ $(get_replica_count) -lt 2 ]
+    if [ get_replica_count -lt 2 ]
     then
       let counter-=1
       sleep 5

--- a/acceptance/redis32/redis-ha.sh
+++ b/acceptance/redis32/redis-ha.sh
@@ -45,7 +45,7 @@ check_number_of_replicas() {
       #echo "The proxy isn't connected to the master. This shouldn't happen"
       #return 1
     #fi
-    if [ get_replica_count -lt 2 ]
+    if [ $((get_replica_count + 0)) -lt 2 ]
     then
       let counter-=1
       sleep 5

--- a/acceptance/redis32/redis-ha.sh
+++ b/acceptance/redis32/redis-ha.sh
@@ -8,6 +8,16 @@ set -xue
 curl -ks -u"${K8S_USERNAME}:${K8S_PASSWORD}" "${K8S_APISERVER}/api/v1/namespaces/default/pods/" | \
 jq '.items[] | select( .metadata.name | test( "'"${SERVICE_ID}"'" ) ) | { name: .metadata.name, node: .status.hostIP, ip: .status.podIP }'
 
+# check proxy for address change.
+# TODO: Will propbably do this with the sentinel logs rather than the proxy logs
+# TODO: Better yet, the acceptance test app should actually make it easy to query this data from the sentinels I think.
+curl -ks -u"${K8S_USERNAME}:${K8S_PASSWORD}" "${K8S_APISERVER}/api/v1/namespaces/default/pods/${POD_NAME}/log" | \
+grep 'Master Address changed' | tail
+
+# delete a pod
+curl -ks -u"${K8S_USERNAME}:${K8S_PASSWORD}" "${K8S_APISERVER}/api/v1/namespaces/default/pods/${POD_NAME}" -XDELETE
+
+
 # run a few tests
 
 # destroy server/0 via k8s API

--- a/acceptance/redis32/redis-ha.sh
+++ b/acceptance/redis32/redis-ha.sh
@@ -33,6 +33,9 @@ get_replica_count() {
   curl -m 2 -kfv "https://${url}/info?s=replication" | jq -re '.connected_slaves'
 }
 
+# Allow for the pre-stop script to execute
+sleep 1
+
 # Iterate on number of replicas to verify that we're at 3x servers
 check_number_of_replicas() {
   counter=120
@@ -42,6 +45,7 @@ check_number_of_replicas() {
     then
       let counter-=1
       sleep 5
+      continue
     fi
     if [ $(($(get_replica_count) + 0)) -lt $replica_count ]
     then
@@ -86,8 +90,5 @@ then
   curl -m 2 -kfv "https://${url}/config-get"
   exit 1
 fi
-
-# Allow for the proxies to find the new master.
-sleep 1
 
 run_tests

--- a/acceptance/redis32/redis-ha.sh
+++ b/acceptance/redis32/redis-ha.sh
@@ -37,6 +37,9 @@ get_replica_count() {
 
 # Iterate on number of replicas to verify that we're at 3x servers
 check_number_of_replicas() {
+  echo "Sleeping for 1 min; do your debugging now!"
+  echo "try running => curl -kfs 'https://${url}/info?s=replication' | jq -re '.role'"
+  sleep 60
   counter=120
   until [ $counter -le 0 ]
   do

--- a/acceptance/redis32/redis-ha.sh
+++ b/acceptance/redis32/redis-ha.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -xe
+set -xue
 
 # Test Redis is working by running `SET`, `GET`, and `DEL`.
 run_tests() {
@@ -13,9 +13,9 @@ run_tests() {
 
 # Get all pods from Kubernetes matching $idx_and_short_serviceid
 get_k8s_pods() {
-  curl -ksf -u"${K8S_USERNAME}:${K8S_PASSWORD}" "${K8S_APISERVER}/api/v1/namespaces/default/pods?labelSelector=idx_and_short_serviceid%3D${idx_and_short_serviceid}" | \
+  curl -G -ksf -u"${K8S_USERNAME}:${K8S_PASSWORD}" "${K8S_APISERVER}/api/v1/namespaces/default/pods?labelSelector=idx_and_short_serviceid%3D${idx_and_short_serviceid}" | \
   jq '.items[] | { name: .metadata.name, node: .status.hostIP, ip: .status.podIP, status: .status.phase }' \ |
-  jq -c -s '.'
+  jq -s '.'
 }
 
 # Get the current primary server's IP address
@@ -64,6 +64,13 @@ primary_server_name=$(
   echo "$(get_k8s_pods)" | \
   jq '.[] | select( .ip == "'${primary_server_ip}'") | .name'
 )
+
+# Check to see if there were any errors retrieving $primary_server_name
+if ! echo $primary_server_name | grep -oE 'x[a-zA-Z0-9]{3,15}' > /dev/null
+then
+  echo "There was an error getting the primary server's name for ${primary_server_ip}"
+  exit 1
+fi
 
 # Delete the current master
 curl -ks -u"${K8S_USERNAME}:${K8S_PASSWORD}" \

--- a/acceptance/redis32/redis-ha.sh
+++ b/acceptance/redis32/redis-ha.sh
@@ -62,11 +62,11 @@ primary_server_ip=$(get_primary_ip)
 
 primary_server_name=$(
   echo "$(get_k8s_pods)" | \
-  jq -re '.[] | select( .ip == "'${primary_server_ip}'") | .name'
+  jq -re '.[] | select( .ip == "'"${primary_server_ip}"'") | .name'
 )
 
 # Check to see if there were any errors retrieving $primary_server_name
-if ! echo $primary_server_name | grep -oE 'x[a-zA-Z0-9]{3,15}' > /dev/null
+if ! echo "${primary_server_name}" | grep -oE 'x[a-zA-Z0-9]{3,15}' > /dev/null
 then
   echo "There was an error getting the primary server's name for ${primary_server_ip}"
   exit 1

--- a/acceptance/redis32/redis-ha.sh
+++ b/acceptance/redis32/redis-ha.sh
@@ -33,9 +33,6 @@ get_replica_count() {
   curl -m 2 -kfv "https://${url}/info?s=replication" | jq -re '.connected_slaves'
 }
 
-# Allow for the pre-stop script to execute
-sleep 1
-
 # Iterate on number of replicas to verify that we're at 3x servers
 check_number_of_replicas() {
   counter=120
@@ -80,6 +77,9 @@ fi
 curl -m 2 -kv -u"${K8S_USERNAME}:${K8S_PASSWORD}" \
   "${K8S_APISERVER}/api/v1/namespaces/default/pods/${primary_server_name}" \
   -XDELETE
+
+# Allow for the pre-stop script to execute
+sleep 1
 
 if ! check_number_of_replicas
 then

--- a/acceptance/redis32/redis-ha.sh
+++ b/acceptance/redis32/redis-ha.sh
@@ -4,7 +4,7 @@ set -xe
 
 # Test Redis is working by running `SET`, `GET`, and `DEL`.
 run_tests() {
-  if $(curl -kfs "https://${URL}/")
+  if $(curl -kfs "https://${url}/")
   then
     echo "error with testing Redis."
     exit 99

--- a/acceptance/redis32/redis-ha.sh
+++ b/acceptance/redis32/redis-ha.sh
@@ -38,11 +38,6 @@ check_number_of_replicas() {
   counter=120
   until [ $counter -le 0 ]
   do
-    if [[ $(get_primary_role) == "" ]]
-    then
-      echo "The proxy isn't connected to Redis. This shouldn't happen"
-      exit 1
-    fi
     if [[ $(get_primary_role) != "master" ]]
     then
       let counter-=1

--- a/acceptance/redis32/redis-ha.sh
+++ b/acceptance/redis32/redis-ha.sh
@@ -87,4 +87,7 @@ then
   exit 1
 fi
 
+# Allow for the proxies to find the new master.
+sleep 1
+
 run_tests

--- a/acceptance/redis32/redis-ha.sh
+++ b/acceptance/redis32/redis-ha.sh
@@ -13,14 +13,14 @@ run_tests() {
 
 # Get all pods from Kubernetes matching $idx_and_short_serviceid
 get_k8s_pods() {
-  curl -ksf -u"${K8S_USERNAME}:${K8S_PASSWORD}" "${K8S_APISERVER}api/v1/namespaces/default/pods?labelSelector=idx_and_short_serviceid%3D${SHORT_SERVICE_ID}" | \
+  curl -ksf -u"${K8S_USERNAME}:${K8S_PASSWORD}" "${K8S_APISERVER}api/v1/namespaces/default/pods?labelSelector=idx_and_short_serviceid%3D${idx_and_short_serviceid}" | \
   jq '.items[] | { name: .metadata.name, node: .status.hostIP, ip: .status.podIP, status: .status.phase }' \ |
   jq -s '.'
 }
 
 # Get the current primary server's IP address
 get_primary_ip() {
-  curl -kfs "https://${url}/config-get?p=slave-annouce-ip" | \
+  curl -kfs "https://${url}/config-get?p=slave-announce-ip" | \
   jq -re '."slave-announce-ip"'
 }
 

--- a/acceptance/redis32/redis-ha.sh
+++ b/acceptance/redis32/redis-ha.sh
@@ -40,12 +40,12 @@ check_number_of_replicas() {
   counter=120
   until [ $counter -le 0 ]
   do
-    #if [[ get_primary_role != "master" ]]
+    #if [[ $(get_primary_role) != "master" ]]
     #then
       #echo "The proxy isn't connected to the master. This shouldn't happen"
       #return 1
     #fi
-    if [ $((get_replica_count + 0)) -lt 2 ]
+    if [ $(($(get_replica_count) + 0)) -lt 2 ]
     then
       let counter-=1
       sleep 5

--- a/acceptance/redis32/redis-ha.sh
+++ b/acceptance/redis32/redis-ha.sh
@@ -14,7 +14,7 @@ run_tests() {
 # Get all pods from Kubernetes matching $idx_and_short_serviceid
 get_k8s_pods() {
   curl -G -ksf -u"${K8S_USERNAME}:${K8S_PASSWORD}" "${K8S_APISERVER}/api/v1/namespaces/default/pods?labelSelector=idx_and_short_serviceid%3D${idx_and_short_serviceid}" | \
-  jq '.items[] | { name: .metadata.name, node: .status.hostIP, ip: .status.podIP, status: .status.phase }' | \
+  jq -re '.items[] | { name: .metadata.name, node: .status.hostIP, ip: .status.podIP, status: .status.phase }' | \
   jq -s '.'
 }
 
@@ -62,7 +62,7 @@ primary_server_ip=$(get_primary_ip)
 
 primary_server_name=$(
   echo "$(get_k8s_pods)" | \
-  jq '.[] | select( .ip == "'${primary_server_ip}'") | .name'
+  jq -re '.[] | select( .ip == "'${primary_server_ip}'") | .name'
 )
 
 # Check to see if there were any errors retrieving $primary_server_name

--- a/acceptance/redis32/redis-ha.sh
+++ b/acceptance/redis32/redis-ha.sh
@@ -13,9 +13,9 @@ run_tests() {
 
 # Get all pods from Kubernetes matching $idx_and_short_serviceid
 get_k8s_pods() {
-  curl -ksf -u"${K8S_USERNAME}:${K8S_PASSWORD}" "${K8S_APISERVER}api/v1/namespaces/default/pods?labelSelector=idx_and_short_serviceid%3D${idx_and_short_serviceid}" | \
+  curl -ksf -u"${K8S_USERNAME}:${K8S_PASSWORD}" "${K8S_APISERVER}/api/v1/namespaces/default/pods?labelSelector=idx_and_short_serviceid%3D${idx_and_short_serviceid}" | \
   jq '.items[] | { name: .metadata.name, node: .status.hostIP, ip: .status.podIP, status: .status.phase }' \ |
-  jq -s '.'
+  jq -c -s '.'
 }
 
 # Get the current primary server's IP address

--- a/acceptance/run-acceptance-test.sh
+++ b/acceptance/run-acceptance-test.sh
@@ -44,6 +44,8 @@ cf bind-service ${APP_NAME} ${SERVICE_INSTANCE_NAME}
 cf start ${APP_NAME}
 
 export url=$(cf app ${APP_NAME} | grep -e "urls: " -e "routes: " | awk '{print $2}')
+export idx_and_short_serviceid=$(cf env ${APP_NAME} | grep -E "hostname.*service.kubernetes" | grep -oE 'x[a-zA-Z0-9]{3,15}')
+
 
 status=$(curl -w "%{http_code}" "https://${url}")
 if [ "${status}" != "200" ]; then

--- a/credentials.example.yml
+++ b/credentials.example.yml
@@ -24,12 +24,12 @@ docker-password: CHANGEME
 docker-repo-fluentd: 18fgsa/fluentd-cloudwatch
 docker-repo-elastic: 18fgsa/docker-elasticsearch-kubernetes-auth
 docker-repo-mongo: 18fgsa/mongo
-docker-repo-redis28: 18fgsa/redis
+docker-repo-redis: 18fgsa/redis
 
 docker-tag-fluentd-cloudwatch: 0.1.0
 docker-tag-elasticsearch-24: 2.4.1
 docker-tag-mongo: 3.2.10
-docker-tag-redis28: latest
+docker-tag-redis32: 3.2.10
 
 docker-repo-redis-sentinel-proxy: 18fgsa/redis-sentinel-proxy
 docker-repo-redis-server-init: 18fgsa/redis-server-init

--- a/credentials.example.yml
+++ b/credentials.example.yml
@@ -13,8 +13,6 @@ pipeline-tasks-git-branch: master
 
 aws-region: us-gov-west-1
 
-stemcell-bucket: cg-stemcell-images
-
 s3-bosh-releases-bucket: SECURE_BUCKET
 
 docker-email: CHANGEME
@@ -133,3 +131,51 @@ tf-state-bucket-staging:
 tf-state-file-staging:
 tf-state-bucket-production:
 tf-state-file-production:
+
+cluster-username-development: 
+kubernetes-development-deployment-bosh-target:
+riemann-podstatus-params-development:
+exporter-auth-username-development:
+cf-space-development-acctests:
+docker-tag-elastic-base:
+kubernetes-config-development-git-url:
+docker-repo-elastic-base:
+cf-space-development:
+tf-state-bucket-development:
+kubernetes-release-development-git-url:
+exporter-auth-password-production:
+kubernetes-development-private-bucket:
+cf-deploy-password-development:
+kubernetes-development-private-passphrase:
+consul-domain-development:
+exporter-auth-password-staging:
+exporter-src-git-branch:
+broker-auth-user-development:
+broker-auth-pass-development:
+kubernetes-release-development-git-branch:
+broker-service-names-development:
+kubernetes-broker-development-git-url:
+kubernetes-development-deployment-bosh-password:
+docker-repo-elastic-ha:
+exporter-src-development-git-uri:
+kubernetes-development-deployment-bosh-deployment:
+cf-deploy-username-development:
+api-server-development:
+cf-token-key-development:
+kube2iam-params-development:
+cf-api-url-development:
+kubernetes-development-deployment-bosh-username:
+cloudwatch-params-development:
+cf-organization-development:
+tf-state-file-development:
+exporter-src-git-uri:
+kubernetes-broker-development-git-branch:
+exporter-auth-username-production:
+exporter-src-development-git-branch:
+kubernetes-config-development-git-branch:
+cf-client-secret-development:
+cluster-password-development:
+docker-tag-elastic-ha:
+exporter-auth-username-staging:
+exporter-auth-password-development:
+cf-token-url-development:

--- a/credentials.example.yml
+++ b/credentials.example.yml
@@ -31,14 +31,6 @@ docker-tag-elasticsearch-24: 2.4.1
 docker-tag-mongo: 3.2.10
 docker-tag-redis32: 3.2.10
 
-docker-repo-redis-sentinel-proxy: 18fgsa/redis-sentinel-proxy
-docker-repo-redis-server-init: 18fgsa/redis-server-init
-docker-repo-redis-sentinel-init: 18fgsa/redis-sentinel-init
-docker-tag-redis-sentinel-proxy: 1.0.0
-docker-tag-redis-server-init: 3.2.10
-docker-tag-redis-sentinel-init: 3.2.10
-
-
 cloudwatch-params-staging: |-
   ---
   meta:

--- a/infrastructure-aws-production.yml
+++ b/infrastructure-aws-production.yml
@@ -6,17 +6,6 @@ instance_groups:
       aws:
         cluster-tag: kubernetes-production
 - name: minion
-  instances: 7
-  networks:
-  - name: services
-    static_ips:
-    - (( grab terraform_outputs.kubernetes_static_ips.[9] ))
-    - (( grab terraform_outputs.kubernetes_static_ips.[10] ))
-    - (( grab terraform_outputs.kubernetes_static_ips.[11] ))
-    - (( grab terraform_outputs.kubernetes_static_ips.[12] ))
-    - (( grab terraform_outputs.kubernetes_static_ips.[13] ))
-    - (( grab terraform_outputs.kubernetes_static_ips.[14] ))
-    - (( grab terraform_outputs.kubernetes_static_ips.[15] ))
   jobs:
   - name: kubernetes-minion
     properties:

--- a/k8s-jobs.yml
+++ b/k8s-jobs.yml
@@ -111,7 +111,7 @@ instance_groups:
           IMAGES: >-
             busybox
             18fgsa/elasticsearch-ha:2.4.4
-            redis:3.2.10
+            18fgsa/redis:3.2.10
             18fgsa/redis-server-init:3.2.10
             18fgsa/redis-sentinel-init:3.2.10
             18fgsa/redis-sentinel-proxy:1.0.0

--- a/k8s-jobs.yml
+++ b/k8s-jobs.yml
@@ -77,7 +77,7 @@ instance_groups:
         ip: (( grab instance_groups.etcd.networks.services.static_ips.[0] ))
 
 - name: minion
-  instances: 5
+  instances: 7
   persistent_disk_type: kubernetes
   vm_extensions: [kubernetes-sg, kubernetes-minion-profile]
   networks:
@@ -88,6 +88,8 @@ instance_groups:
     - (( grab terraform_outputs.kubernetes_static_ips.[11] ))
     - (( grab terraform_outputs.kubernetes_static_ips.[12] ))
     - (( grab terraform_outputs.kubernetes_static_ips.[13] ))
+    - (( grab terraform_outputs.kubernetes_static_ips.[14] ))
+    - (( grab terraform_outputs.kubernetes_static_ips.[15] ))
   jobs:
   - name: docker
     properties:

--- a/pipeline.yml
+++ b/pipeline.yml
@@ -118,7 +118,7 @@ params:
       TEST_PATH: kubernetes-config/acceptance/redis28
     redis32-tests: &redis32-tests
       SERVICE_NAME: redis32
-      PLAN_NAME: 3x-ha
+      PLAN_NAME: standard-ha
       TEST_PATH: kubernetes-config/acceptance/redis32
     mongodb32-tests: &mongodb32-tests
       SERVICE_NAME: mongodb32

--- a/pipeline.yml
+++ b/pipeline.yml
@@ -521,11 +521,11 @@ jobs:
       params:
         <<: *cf-staging-tests
         <<: *redis28-tests
-    - task: acceptance-test-redis32-ha
-      file: kubernetes-config/acceptance/run-acceptance-test.yml
-      params:
-        <<: *cf-staging-tests
-        <<: *redis32-tests
+    #- task: acceptance-test-redis32-ha
+      #file: kubernetes-config/acceptance/run-acceptance-test.yml
+      #params:
+        #<<: *cf-staging-tests
+        #<<: *redis32-tests
     - task: acceptance-test-mongo32-standard
       file: kubernetes-config/acceptance/run-acceptance-test.yml
       params:
@@ -668,11 +668,11 @@ jobs:
       params:
         <<: *cf-production-tests
         <<: *redis28-tests
-    - task: acceptance-test-redis32-ha
-      file: kubernetes-config/acceptance/run-acceptance-test.yml
-      params:
-        <<: *cf-production-tests
-        <<: *redis32-tests
+    #- task: acceptance-test-redis32-ha
+      #file: kubernetes-config/acceptance/run-acceptance-test.yml
+      #params:
+        #<<: *cf-production-tests
+        #<<: *redis32-tests
     - task: acceptance-test-mongo32-standard
       file: kubernetes-config/acceptance/run-acceptance-test.yml
       params:

--- a/pipeline.yml
+++ b/pipeline.yml
@@ -173,6 +173,8 @@ jobs:
 
 - name: redis32
   plan:
+  - get: erry-day
+    trigger: true
   - get: kubernetes-broker-images
     trigger: true
   - put: docker-hub-redis32

--- a/pipeline.yml
+++ b/pipeline.yml
@@ -116,6 +116,10 @@ params:
       SERVICE_NAME: redis28
       PLAN_NAME: standard
       TEST_PATH: kubernetes-config/acceptance/redis28
+    redis32-tests: &redis32-tests
+      SERVICE_NAME: redis32
+      PLAN_NAME: 3x-ha
+      TEST_PATH: kubernetes-config/acceptance/redis32
     mongodb32-tests: &mongodb32-tests
       SERVICE_NAME: mongodb32
       PLAN_NAME: standard
@@ -352,6 +356,11 @@ jobs:
       params:
         <<: *cf-development-tests
         <<: *redis28-tests
+    - task: acceptance-test-redis32-ha
+      file: kubernetes-config/acceptance/run-acceptance-test.yml
+      params:
+        <<: *cf-development-tests
+        <<: *redis32-tests
     - task: acceptance-test-mongo32-standard
       file: kubernetes-config/acceptance/run-acceptance-test.yml
       params:
@@ -512,6 +521,11 @@ jobs:
       params:
         <<: *cf-staging-tests
         <<: *redis28-tests
+    - task: acceptance-test-redis32-ha
+      file: kubernetes-config/acceptance/run-acceptance-test.yml
+      params:
+        <<: *cf-staging-tests
+        <<: *redis32-tests
     - task: acceptance-test-mongo32-standard
       file: kubernetes-config/acceptance/run-acceptance-test.yml
       params:
@@ -654,6 +668,11 @@ jobs:
       params:
         <<: *cf-production-tests
         <<: *redis28-tests
+    - task: acceptance-test-redis32-ha
+      file: kubernetes-config/acceptance/run-acceptance-test.yml
+      params:
+        <<: *cf-production-tests
+        <<: *redis32-tests
     - task: acceptance-test-mongo32-standard
       file: kubernetes-config/acceptance/run-acceptance-test.yml
       params:

--- a/pipeline.yml
+++ b/pipeline.yml
@@ -361,6 +361,11 @@ jobs:
       params:
         <<: *cf-development-tests
         <<: *redis32-tests
+        # EXTRA TESTS are executed with CWD = TEST_PATH
+        EXTRA_TESTS: ./redis-ha.sh
+        K8S_USERNAME: ((cluster-username-development))
+        K8S_PASSWORD: ((cluster-password-development))
+        K8S_APISERVER: ((api-server-development))
     - task: acceptance-test-mongo32-standard
       file: kubernetes-config/acceptance/run-acceptance-test.yml
       params:

--- a/pipeline.yml
+++ b/pipeline.yml
@@ -526,11 +526,16 @@ jobs:
       params:
         <<: *cf-staging-tests
         <<: *redis28-tests
-    #- task: acceptance-test-redis32-ha
-      #file: kubernetes-config/acceptance/run-acceptance-test.yml
-      #params:
-        #<<: *cf-staging-tests
-        #<<: *redis32-tests
+    - task: acceptance-test-redis32-ha
+      file: kubernetes-config/acceptance/run-acceptance-test.yml
+      params:
+        <<: *cf-staging-tests
+        <<: *redis32-tests
+        # EXTRA TESTS are executed with CWD = TEST_PATH
+        EXTRA_TESTS: ./redis-ha.sh
+        K8S_USERNAME: ((cluster-username-staging))
+        K8S_PASSWORD: ((cluster-password-staging))
+        K8S_APISERVER: ((api-server-staging))
     - task: acceptance-test-mongo32-standard
       file: kubernetes-config/acceptance/run-acceptance-test.yml
       params:
@@ -673,11 +678,16 @@ jobs:
       params:
         <<: *cf-production-tests
         <<: *redis28-tests
-    #- task: acceptance-test-redis32-ha
-      #file: kubernetes-config/acceptance/run-acceptance-test.yml
-      #params:
-        #<<: *cf-production-tests
-        #<<: *redis32-tests
+    - task: acceptance-test-redis32-ha
+      file: kubernetes-config/acceptance/run-acceptance-test.yml
+      params:
+        <<: *cf-production-tests
+        <<: *redis32-tests
+        # EXTRA TESTS are executed with CWD = TEST_PATH
+        EXTRA_TESTS: ./redis-ha.sh
+        K8S_USERNAME: ((cluster-username-production))
+        K8S_PASSWORD: ((cluster-password-production))
+        K8S_APISERVER: ((api-server-production))
     - task: acceptance-test-mongo32-standard
       file: kubernetes-config/acceptance/run-acceptance-test.yml
       params:

--- a/pipeline.yml
+++ b/pipeline.yml
@@ -5,10 +5,7 @@ groups:
   - fluentd-cloudwatch
   - elasticsearch-24
   - mongo-32
-  - redis-sentinel-proxy
-  - redis-sentinel-init
-  - redis-server-init
-  - redis28
+  - redis32
   - deploy-kubernetes-development
   - deploy-kubernetes-broker-development
   - acceptance-tests-development
@@ -48,10 +45,7 @@ groups:
   - mongo-32
   - elasticsearch-base
   - elasticsearch-ha
-  - redis-sentinel-proxy
-  - redis-sentinel-init
-  - redis-server-init
-  - redis28
+  - redis32
 
 params:
   development:
@@ -177,36 +171,13 @@ jobs:
     params:
       build: kubernetes-broker-images/custom_images/elasticsearch-pet-24
 
-- name: redis-sentinel-proxy
+- name: redis32
   plan:
   - get: kubernetes-broker-images
     trigger: true
-  - put: docker-hub-redis-sentinel-proxy
+  - put: docker-hub-redis32
     params:
-      build: kubernetes-broker-images/custom_images/redis-3.2/proxy
-
-- name: redis-sentinel-init
-  plan:
-  - get: kubernetes-broker-images
-    trigger: true
-  - put: docker-hub-redis-sentinel-init
-    params:
-      build: kubernetes-broker-images/custom_images/redis-3.2/sentinel
-
-- name: redis-server-init
-  plan:
-  - get: kubernetes-broker-images
-    trigger: true
-  - put: docker-hub-redis-server-init
-    params:
-      build: kubernetes-broker-images/custom_images/redis-3.2/server
-- name: redis28
-  plan:
-  - get: kubernetes-broker-images
-    trigger: true
-  - put: docker-hub-redis28
-    params:
-      build: kubernetes-broker-images/custom_images/redis
+      build: kubernetes-broker-images/custom_images/redis-3.2
 
 - name: deploy-kubernetes-development
   serial: true
@@ -1085,41 +1056,15 @@ resources:
     repository: ((docker-repo-elastic-ha))
     tag: ((docker-tag-elastic-ha))
 
-- name: docker-hub-redis-sentinel-init
+- name: docker-hub-redis32
   type: docker-image
   source:
     email: ((docker-email))
     username: ((docker-username))
     password: ((docker-password))
-    repository: ((docker-repo-redis-sentinel-init))
-    tag: ((docker-tag-redis-sentinel-init))
+    repository: ((docker-repo-redis))
+    tag: ((docker-tag-redis32))
 
-- name: docker-hub-redis-sentinel-proxy
-  type: docker-image
-  source:
-    email: ((docker-email))
-    username: ((docker-username))
-    password: ((docker-password))
-    repository: ((docker-repo-redis-sentinel-proxy))
-    tag: ((docker-tag-redis-sentinel-proxy))
-
-- name: docker-hub-redis-server-init
-  type: docker-image
-  source:
-    email: ((docker-email))
-    username: ((docker-username))
-    password: ((docker-password))
-    repository: ((docker-repo-redis-server-init))
-    tag: ((docker-tag-redis-server-init))
-
-- name: docker-hub-redis28
-  type: docker-image
-  source:
-    email: ((docker-email))
-    username: ((docker-username))
-    password: ((docker-password))
-    repository: ((docker-repo-redis28))
-    tag: ((docker-tag-redis28))
 
 - &kubernetes-release-tarball
   name: kubernetes-release-tarball


### PR DESCRIPTION
pairing with @linuxbozo

### Implementation Sketch

- [x] add redis32-test application with connection pools
- [x] add redis-ha script for orchestrating app and k8s interactions
- [x] test in dev


Tests are passing in development right now. You can verify this work by going to the pipeline/job and run the `redis32-ha` tests in development.