### PR TITLE
Skip acceptance space delete if not exists.

### DIFF
--- a/acceptance/clear-acceptance-space.sh
+++ b/acceptance/clear-acceptance-space.sh
@@ -5,4 +5,7 @@ set -eux
 cf api ${CF_API_URL}
 (set +x; cf auth $CF_USERNAME $CF_PASSWORD)
 
-cf delete-space -f -o ${CF_ORGANIZATION} ${CF_SPACE}
+cf target -o ${CF_ORGANIZATION}
+if cf space ${CF_SPACE}; then
+  cf delete-space -f ${CF_SPACE}
+fi


### PR DESCRIPTION
Handles the edge case where the acceptance tests space doesn't exist to begin with.

h/t @LinuxBozo 