### PR TITLE
realign the core components so minions can scale across all envs.

### DIFF
--- a/k8s-jobs.yml
+++ b/k8s-jobs.yml
@@ -9,9 +9,9 @@ instance_groups:
   networks:
   - name: services
     static_ips:
-    - (( grab terraform_outputs.kubernetes_static_ips.[10] ))
-    - (( grab terraform_outputs.kubernetes_static_ips.[11] ))
-    - (( grab terraform_outputs.kubernetes_static_ips.[12] ))
+    - (( grab terraform_outputs.kubernetes_static_ips.[4] ))
+    - (( grab terraform_outputs.kubernetes_static_ips.[5] ))
+    - (( grab terraform_outputs.kubernetes_static_ips.[6] ))
   jobs:
   - name: consul
     properties:
@@ -29,9 +29,9 @@ instance_groups:
   networks:
   - name: services
     static_ips:
-    - (( grab terraform_outputs.kubernetes_static_ips.[15] ))
-    - (( grab terraform_outputs.kubernetes_static_ips.[16] ))
-    - (( grab terraform_outputs.kubernetes_static_ips.[17] ))
+    - (( grab terraform_outputs.kubernetes_static_ips.[7] ))
+    - (( grab terraform_outputs.kubernetes_static_ips.[8] ))
+    - (( grab terraform_outputs.kubernetes_static_ips.[9] ))
   jobs:
   - (( append ))
   - name: cron


### PR DESCRIPTION
These values are not overriden by each of the environments, so all of them need to be aligned like this.

Signed-off-by: Mike Lloyd <mike.lloyd@gsa.gov>