### PR TITLE
updated max in flight for prod.

### DIFF
--- a/infrastructure-aws-staging.yml
+++ b/infrastructure-aws-staging.yml
@@ -36,3 +36,5 @@ instance_groups:
     properties:
       aws:
         cluster-tag: kubernetes-staging
+update:
+  max_in_flight: 10%


### PR DESCRIPTION
Increasing max-in-flight in prod.

Confirmed percentage variables work:

```sh
Using deployment 'cfcr'

Release 'cfcr-etcd/1.11.1' already exists.

Release 'docker/35.3.3' already exists.

Release 'bpm/1.0.4' already exists.

Task 151

Task 151 | 19:38:11 | Downloading remote release: Downloading remote release (00:00:16)
Task 151 | 19:38:27 | Verifying remote release: Verifying remote release (00:00:02)
Task 151 | 19:38:29 | Extracting release: Extracting release (00:00:07)
Task 151 | 19:38:36 | Verifying manifest: Verifying manifest (00:00:00)
Task 151 | 19:38:36 | Resolving package dependencies: Resolving package dependencies (00:00:00)
Task 151 | 19:38:36 | Processing 14 existing jobs: Processing 14 existing jobs (00:00:00)
Task 151 | 19:38:36 | Compiled Release has been created: kubo/0.38.0 (00:00:00)

Task 151 Started  Mon Oct 21 19:38:11 UTC 2019
Task 151 Finished Mon Oct 21 19:38:36 UTC 2019
Task 151 Duration 00:00:25
Task 151 done
  update:
-   max_in_flight: 33
+   max_in_flight: 33%

Continue? [yN]: y

Task 152

Task 152 | 19:38:42 | Preparing deployment: Preparing deployment (00:00:26)
Task 152 | 19:39:08 | Preparing deployment: Rendering templates (00:00:14)
Task 152 | 19:39:22 | Preparing package compilation: Finding packages to compile (00:00:01)

Task 152 Started  Mon Oct 21 19:38:42 UTC 2019
Task 152 Finished Mon Oct 21 19:39:23 UTC 2019
Task 152 Duration 00:00:41
Task 152 done

Succeeded
```

Signed-off-by: Mike Lloyd <mike.lloyd@gsa.gov>