### PR TITLE
fix conflicting IPs

### DIFF
--- a/k8s-jobs.yml
+++ b/k8s-jobs.yml
@@ -90,13 +90,14 @@ instance_groups:
   networks:
   - name: services
     static_ips:
-    - (( grab terraform_outputs.kubernetes_static_ips.[9] ))
     - (( grab terraform_outputs.kubernetes_static_ips.[10] ))
     - (( grab terraform_outputs.kubernetes_static_ips.[11] ))
     - (( grab terraform_outputs.kubernetes_static_ips.[12] ))
     - (( grab terraform_outputs.kubernetes_static_ips.[13] ))
     - (( grab terraform_outputs.kubernetes_static_ips.[14] ))
     - (( grab terraform_outputs.kubernetes_static_ips.[15] ))
+    - (( grab terraform_outputs.kubernetes_static_ips.[16] ))
+
   jobs:
   - name: docker
     properties:


### PR DESCRIPTION
*This change should only affect development* other environments override the IP addresses, since they have different numbers of minions

etcd and minions are both trying to grab the 9th IP, so dev can never deploy.