### PR TITLE
run correct tests in production

### DIFF
--- a/pipeline.yml
+++ b/pipeline.yml
@@ -1045,12 +1045,12 @@ jobs:
     - task: acceptance-test-elasticsearch56
       file: kubernetes-config/acceptance/run-acceptance-test.yml
       params:
-        <<: *cf-staging-tests
+        <<: *cf-production-tests
         <<: *elasticsearch56-tests
     - task: acceptance-test-elasticsearch56-ha
       file: kubernetes-config/acceptance/run-acceptance-test.yml
       params:
-        <<: *cf-staging-tests
+        <<: *cf-production-tests
         SERVICE_NAME: elasticsearch56
         PLAN_NAME: medium-ha
         TEST_PATH: kubernetes-config/acceptance/elasticsearch56


### PR DESCRIPTION
This fixes an error that causes the production acceptance tests job to run staging acceptance tests.