### PR TITLE
setting minion scale to 6 due to scheduling predicate limitations.

### DIFF
--- a/infrastructure-aws-development.yml
+++ b/infrastructure-aws-development.yml
@@ -33,7 +33,7 @@ instance_groups:
         cluster-tag: kubernetes-development
 - name: minion
   vm_type: r4.large
-  instances: 5
+  instances: 6
   networks:
   - name: services
     static_ips:
@@ -42,6 +42,7 @@ instance_groups:
     - (( grab terraform_outputs.kubernetes_static_ips.[12] ))
     - (( grab terraform_outputs.kubernetes_static_ips.[13] ))
     - (( grab terraform_outputs.kubernetes_static_ips.[14] ))
+    - (( grab terraform_outputs.kubernetes_static_ips.[15] ))
   jobs:
   - name: kubernetes-minion
     properties:

--- a/infrastructure-aws-staging.yml
+++ b/infrastructure-aws-staging.yml
@@ -13,13 +13,17 @@ instance_groups:
       aws:
         cluster-tag: kubernetes-staging
 - name: minion
-  instances: 3
+  vm_type: r4.large
+  instances: 6
   networks:
   - name: services
     static_ips:
-    - (( grab terraform_outputs.kubernetes_static_ips.[36] ))
-    - (( grab terraform_outputs.kubernetes_static_ips.[37] ))
-    - (( grab terraform_outputs.kubernetes_static_ips.[38] ))
+    - (( grab terraform_outputs.kubernetes_static_ips.[10] ))
+    - (( grab terraform_outputs.kubernetes_static_ips.[11] ))
+    - (( grab terraform_outputs.kubernetes_static_ips.[12] ))
+    - (( grab terraform_outputs.kubernetes_static_ips.[13] ))
+    - (( grab terraform_outputs.kubernetes_static_ips.[14] ))
+    - (( grab terraform_outputs.kubernetes_static_ips.[15] ))
   jobs:
   - name: kubernetes-minion
     properties:


### PR DESCRIPTION
## Changes proposed in this pull request:
- setting minion scale to 6 due to scheduling predicate limitations. it won't pass the acceptance tests.

## security considerations

None.

Signed-off-by: Mike Lloyd <mike.lloyd@gsa.gov>